### PR TITLE
Add link to referenced book

### DIFF
--- a/src/epub/text/endnotes.xhtml
+++ b/src/epub/text/endnotes.xhtml
@@ -10,7 +10,7 @@
 			<h2 epub:type="title">Endnotes</h2>
 			<ol>
 				<li id="note-1" epub:type="endnote">
-					<p>See <i epub:type="se:name.publication.book">The Black Star Passes</i>, Ace Books, F-346. <a href="prologue.xhtml#noteref-1" epub:type="backlink">↩</a></p>
+					<p>See <a href="https://standardebooks.org/ebooks/john-w-campbell/the-black-star-passes"><i epub:type="se:name.publication.book">The Black Star Passes</i></a>, Ace Books, F-346. <a href="prologue.xhtml#noteref-1" epub:type="backlink">↩</a></p>
 				</li>
 			</ol>
 		</section>


### PR DESCRIPTION
Now that standardebooks has produced the Black Star Passes, we can link it from the endnotes.